### PR TITLE
STNDP-25 Add active state on appearance

### DIFF
--- a/apps/web/app/routes/board-layout-route/nav-bar.tsx
+++ b/apps/web/app/routes/board-layout-route/nav-bar.tsx
@@ -137,6 +137,9 @@ function NavBar() {
               <DropdownMenu.SubTrigger>Appearance</DropdownMenu.SubTrigger>
               <DropdownMenu.SubContent>
                 <DropdownMenu.Item
+                  className={
+                    appearance === "light" ? "bg-[var(--accent-a3)]" : ""
+                  }
                   onClick={() => {
                     setAppearance("light");
                   }}
@@ -144,6 +147,9 @@ function NavBar() {
                   Light
                 </DropdownMenu.Item>
                 <DropdownMenu.Item
+                  className={
+                    appearance === "dark" ? "bg-[var(--accent-a3)]" : ""
+                  }
                   onClick={() => {
                     setAppearance("dark");
                   }}
@@ -151,6 +157,9 @@ function NavBar() {
                   Dark
                 </DropdownMenu.Item>
                 <DropdownMenu.Item
+                  className={
+                    appearance === "inherit" ? "bg-[var(--accent-a3)]" : ""
+                  }
                   onClick={() => {
                     setAppearance("inherit");
                   }}


### PR DESCRIPTION
I referred to the existing code for the dropdown menu’s gray color.
```
bg-[var(--accent-a3)]
```


### Updated Result
![Mar-25-2025 16-55-53](https://github.com/user-attachments/assets/a58d6c77-59d5-4079-9dd2-6b89f2b50353)
