### PR TITLE
STNDP-11 Accessing a board without the permission should show a 404

### DIFF
--- a/apps/web/app/libs/auth.ts
+++ b/apps/web/app/libs/auth.ts
@@ -1,7 +1,7 @@
 import { getSession } from "./auth-session.server";
 
 import { redirect, type Session } from "react-router";
-import { isApiErrorResponse, type ApiResponse } from "types";
+import { isErrorData, type ApiData } from "types";
 import { commitSession } from "./auth-session.server";
 
 function verifyAccessToken(accessToken: string) {
@@ -11,7 +11,7 @@ function verifyAccessToken(accessToken: string) {
       Authorization: `Bearer ${accessToken}`,
     },
   }).then(
-    (response) => response.json() as Promise<ApiResponse<{ valid: boolean }>>
+    (response) => response.json() as Promise<ApiData<{ valid: boolean }>>
   );
 }
 
@@ -22,8 +22,7 @@ function refreshAccessToken(refreshToken: string) {
       method: "POST",
     }
   ).then(
-    (response) =>
-      response.json() as Promise<ApiResponse<{ access_token: string }>>
+    (response) => response.json() as Promise<ApiData<{ access_token: string }>>
   );
 }
 
@@ -37,7 +36,7 @@ async function verifyTokenAndRefresh(session: Session) {
 
   const verificationResponse = await verifyAccessToken(accessToken);
 
-  if (!isApiErrorResponse(verificationResponse)) {
+  if (!isErrorData(verificationResponse)) {
     return {
       accessToken,
       refreshed: false,
@@ -52,7 +51,7 @@ async function verifyTokenAndRefresh(session: Session) {
 
   const response = await refreshAccessToken(refreshToken);
 
-  if (!isApiErrorResponse(response)) {
+  if (!isErrorData(response)) {
     return {
       accessToken: response.access_token,
       refreshed: true,

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -1,5 +1,4 @@
 import {
-  isRouteErrorResponse,
   Links,
   Meta,
   Outlet,
@@ -149,66 +148,30 @@ export default function App() {
 }
 
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  let message = "Oops!";
-  let details = "An unexpected error occurred.";
-  let stack: string | undefined;
+  let title = "Oops!";
+  let description = "An unexpected error occurred.";
 
-  if (isRouteErrorResponse(error)) {
-    message = error.status === 404 ? "404" : "Error";
-    details =
-      error.status === 404
-        ? "The requested page could not be found."
-        : error.statusText || details;
-  } else if (import.meta.env.DEV && error && error instanceof Error) {
-    details = error.message;
-    stack = error.stack;
+  if (isApiError(error)) {
+    title = error.statusCode.toString();
+    description = error.message;
   }
 
   return (
     <main className="pt-16 p-4 container mx-auto">
-      404
-      {/* <h1>{message}</h1>
-      <p>{details}</p>
-      {stack && (
-        <pre className="w-full p-4 overflow-x-auto">
-          <code>{stack}</code>
-        </pre>
-      )} */}
+      <h1>{title}</h1>
+      <p>{description}</p>
     </main>
   );
 }
 
-/**
- * RouteErrorResponse implementation based on React Router's original implementation
- * @see https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/router/utils.ts
- */
-export class RouteErrorResponse implements ErrorResponse {
-  status: number;
-  statusText: string;
-  data: any;
-  private error?: Error;
-  private internal: boolean;
-
-  constructor(
-    status: number,
-    statusText: string | undefined,
-    data: any,
-    internal = false
-  ) {
-    this.status = status;
-    this.statusText = statusText || "";
-    this.internal = internal;
-    if (data instanceof Error) {
-      this.data = data.toString();
-      this.error = data;
-    } else {
-      this.data = data;
-    }
+export class ApiError extends Error {
+  statusCode: number;
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.statusCode = statusCode;
   }
 }
 
-export class NotFoundRouteErrorResponse extends RouteErrorResponse {
-  constructor() {
-    super(404, "Not found", Error("Not found"));
-  }
+function isApiError(error: any): error is ApiError {
+  return "statusCode" in error;
 }

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -166,13 +166,14 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
 
   return (
     <main className="pt-16 p-4 container mx-auto">
-      <h1>{message}</h1>
+      404
+      {/* <h1>{message}</h1>
       <p>{details}</p>
       {stack && (
         <pre className="w-full p-4 overflow-x-auto">
           <code>{stack}</code>
         </pre>
-      )}
+      )} */}
     </main>
   );
 }

--- a/apps/web/app/routes/board-layout-route/nav-bar.tsx
+++ b/apps/web/app/routes/board-layout-route/nav-bar.tsx
@@ -17,7 +17,7 @@ import { useUserAppearanceSetting } from "~/context/UserAppearanceSettingContext
 import { alertFeatureNotImplemented } from "~/libs/alert";
 
 function NavBar() {
-  const { currentUserBoardsDataPromise, currentUserDataPromise } =
+  const { currentUser, currentUserBoards } =
     useLoaderData<Route.ComponentProps["loaderData"]>();
 
   const { boardId } = useParams();
@@ -65,8 +65,22 @@ function NavBar() {
                 </>
               }
             >
-              <Await resolve={currentUserBoardsDataPromise}>
+              <Await resolve={currentUserBoards}>
                 {(data) => {
+                  if (!data) {
+                    return (
+                      <>
+                        <DropdownMenu.Separator />
+                        <DropdownMenu.Label>Boards</DropdownMenu.Label>
+                        <DropdownMenu.Item>
+                          <Text>
+                            <Skeleton>Example</Skeleton>
+                          </Text>
+                        </DropdownMenu.Item>
+                      </>
+                    );
+                  }
+
                   const sharedBoards = data.filter(
                     (board) => board.usersCount > 1
                   );
@@ -182,8 +196,12 @@ function NavBar() {
                 <PersonIcon />
                 <Text size="2">
                   <Suspense fallback={<Skeleton>Loading</Skeleton>}>
-                    <Await resolve={currentUserDataPromise}>
+                    <Await resolve={currentUser}>
                       {(data) => {
+                        if (!data) {
+                          return <Skeleton>Loading</Skeleton>;
+                        }
+
                         return <>{data.primary_email}</>;
                       }}
                     </Await>

--- a/apps/web/app/routes/board-route/board-route.tsx
+++ b/apps/web/app/routes/board-route/board-route.tsx
@@ -1,10 +1,10 @@
 import { Container, Flex } from "@radix-ui/themes";
 
 import type { Route } from "./+types/board-route";
-import { RouteErrorResponse } from "~/root";
+import { ApiError } from "~/root";
 import {
-  isApiErrorResponse,
-  type ApiResponse,
+  isErrorData,
+  type ApiData,
   type Board,
   type Standup,
   type StandupFormStructure,
@@ -14,13 +14,15 @@ import verifyAuthentication from "~/libs/auth";
 import Toolbar from "./toolbar";
 import TodaysStandup from "./todays-standup";
 import PastStandups from "./past-standups";
+import { Suspense } from "react";
+import { Await, data, useLoaderData } from "react-router";
 
 function getBoard(boardId: string, { accessToken }: { accessToken: string }) {
   return fetch(import.meta.env.VITE_API_URL + `/boards/${boardId}`, {
     headers: {
       Authorization: `Bearer ${accessToken}`,
     },
-  }).then((response) => response.json() as Promise<ApiResponse<Board>>);
+  }).then((response) => response.json() as Promise<ApiData<Board>>);
 }
 
 function getStandupFormStructure(
@@ -39,7 +41,7 @@ function getStandupFormStructure(
       },
     }
   ).then(
-    (response) => response.json() as Promise<ApiResponse<StandupFormStructure>>
+    (response) => response.json() as Promise<ApiData<StandupFormStructure>>
   );
 }
 
@@ -51,7 +53,7 @@ function listStandups(
     headers: {
       Authorization: `Bearer ${accessToken}`,
     },
-  }).then((response) => response.json() as Promise<ApiResponse<Standup[]>>);
+  }).then((response) => response.json() as Promise<ApiData<Standup[]>>);
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
@@ -59,32 +61,31 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 
   const boardId = params.boardId;
 
-  const boardPromise = getBoard(boardId, { accessToken }).then((data) => {
-    if (isApiErrorResponse(data)) {
-      throw new RouteErrorResponse(
-        data.statusCode,
-        data.message,
-        Error(data.error)
-      );
+  const boardDataPromise = getBoard(boardId, { accessToken });
+
+  const boardPromise = boardDataPromise.then((data) => {
+    if (isErrorData(data)) {
+      return null;
     }
     return data;
   });
 
   const standupsPromise = listStandups(boardId, { accessToken }).then(
     (data) => {
-      if (isApiErrorResponse(data)) {
-        throw new RouteErrorResponse(
-          data.statusCode,
-          data.message,
-          Error(data.error)
-        );
+      if (isErrorData(data)) {
+        return null;
       }
       return data;
     }
   );
 
   const standupFormStructuresPromise = standupsPromise.then((standups) => {
+    if (!standups) {
+      return null;
+    }
+
     const ids = standups.map((standup) => standup.formStructureId);
+
     return fetch(
       import.meta.env.VITE_API_URL +
         `/boards/${boardId}/standup-form-structures?ids=${ids.join(",")}`,
@@ -97,60 +98,77 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     )
       .then(
         (response) =>
-          response.json() as Promise<ApiResponse<StandupFormStructure[]>>
+          response.json() as Promise<ApiData<StandupFormStructure[]>>
       )
       .then((data) => {
-        if (isApiErrorResponse(data)) {
-          throw new RouteErrorResponse(
-            data.statusCode,
-            data.message,
-            Error(data.error)
-          );
+        if (isErrorData(data)) {
+          return null;
         }
         return data;
       });
   });
 
-  const boardActiveStandupFormStructurePromise = boardPromise.then(
-    async (board) => {
-      if (!board.activeStandupFormStructureId) {
+  const boardActiveStandupFormStructurePromise = boardPromise.then((board) => {
+    if (!board) {
+      return null;
+    }
+
+    if (!board.activeStandupFormStructureId) {
+      return null;
+    }
+
+    return getStandupFormStructure(
+      {
+        standupFormStructureId: board.activeStandupFormStructureId,
+        boardId: board.id,
+      },
+      { accessToken }
+    ).then((data) => {
+      if (isErrorData(data)) {
         return null;
       }
-      return getStandupFormStructure(
-        {
-          standupFormStructureId: board.activeStandupFormStructureId,
-          boardId: board.id,
-        },
-        { accessToken }
-      ).then((data) => {
-        if (isApiErrorResponse(data)) {
-          throw new RouteErrorResponse(
-            data.statusCode,
-            data.message,
-            Error(data.error)
-          );
-        }
-        return data;
-      });
-    }
-  );
+      return data;
+    });
+  });
 
-  return {
+  return data({
+    boardDataPromise,
     boardPromise,
     standupsPromise,
     boardActiveStandupFormStructurePromise,
     standupFormStructuresPromise,
-  };
+  });
+}
+
+function BoardExistanceGuard() {
+  const { boardDataPromise } = useLoaderData<typeof loader>();
+
+  return (
+    <Suspense>
+      <Await resolve={boardDataPromise}>
+        {(data) => {
+          if (isErrorData(data)) {
+            throw new ApiError(data.message, data.statusCode);
+          }
+          return null;
+        }}
+      </Await>
+    </Suspense>
+  );
 }
 
 export default function BoardRoute({}: Route.ComponentProps) {
   return (
-    <Container my="7" maxWidth="672px" px="4">
-      <Flex direction="column" gap="7">
-        <Toolbar />
-        <TodaysStandup />
-        <PastStandups />
-      </Flex>
-    </Container>
+    <>
+      <BoardExistanceGuard />
+
+      <Container my="7" maxWidth="672px" px="4">
+        <Flex direction="column" gap="7">
+          <Toolbar />
+          <TodaysStandup />
+          <PastStandups />
+        </Flex>
+      </Container>
+    </>
   );
 }

--- a/apps/web/app/routes/board-route/past-standups.tsx
+++ b/apps/web/app/routes/board-route/past-standups.tsx
@@ -7,7 +7,7 @@ import {
   type DynamicFormValues,
 } from "./dynamic-form";
 import { Box, Card, Flex, Skeleton, Text, Tooltip } from "@radix-ui/themes";
-import type { Standup } from "types";
+import { type Standup } from "types";
 import { parseMarkdownToHtml } from "~/libs/markdown";
 
 type Props = {};
@@ -17,8 +17,17 @@ function Standups() {
     useLoaderData<typeof loader>();
 
   const board = use(boardPromise);
+
+  if (!board) {
+    return <SuspenseFallback />;
+  }
+
   const standups = use(standupsPromise);
   const standupFormStructures = use(standupFormStructuresPromise);
+
+  if (!standups || !standupFormStructures) {
+    return <SuspenseFallback />;
+  }
 
   const boardTimezone = board.timezone;
 

--- a/apps/web/app/routes/board-route/todays-standup.tsx
+++ b/apps/web/app/routes/board-route/todays-standup.tsx
@@ -43,10 +43,19 @@ function CardContent({ ref }: { ref: Ref<CardContentRef> }) {
   } = useLoaderData<typeof loader>();
 
   const board = use(boardPromise);
-  const standups: Standup[] = use(standupsPromise);
+
+  if (!board) {
+    return <FormSkeleton />;
+  }
+
+  const standups: Standup[] | null = use(standupsPromise);
   const structure = use(boardActiveStandupFormStructurePromise);
 
-  const schema = validateDynamicFormSchema(structure?.schema);
+  if (!standups || !structure) {
+    return <FormSkeleton />;
+  }
+
+  const schema = validateDynamicFormSchema(structure.schema);
 
   const dynamicFormRef = useRef<DynamicFormRef>(null);
 

--- a/apps/web/app/routes/board-route/toolbar.tsx
+++ b/apps/web/app/routes/board-route/toolbar.tsx
@@ -1,14 +1,24 @@
 import { Share1Icon, GearIcon } from "@radix-ui/react-icons";
-import { Flex, Skeleton, Button, Text, Tooltip } from "@radix-ui/themes";
-import React, { Suspense } from "react";
-import { Await, Link, useLoaderData, useParams } from "react-router";
+import { Flex, Skeleton, Button, Text } from "@radix-ui/themes";
+import { Suspense, use } from "react";
+import { Link, useLoaderData, useParams } from "react-router";
 import type { loader } from "./board-route";
+
+function BoardName() {
+  const { boardPromise } = useLoaderData<typeof loader>();
+
+  const board = use(boardPromise);
+
+  if (!board) {
+    return <Skeleton>Sample name</Skeleton>;
+  }
+
+  return <>{board.name}</>;
+}
 
 type Props = {};
 
 function Toolbar({}: Props) {
-  const { boardPromise } = useLoaderData<typeof loader>();
-
   const { boardId } = useParams();
 
   return (
@@ -25,11 +35,7 @@ function Toolbar({}: Props) {
     >
       <Text size="6" weight="bold">
         <Suspense fallback={<Skeleton>Sample name</Skeleton>}>
-          <Await resolve={boardPromise}>
-            {(data) => {
-              return <>{data.name}</>;
-            }}
-          </Await>
+          <BoardName />
         </Suspense>
       </Text>
 

--- a/apps/web/app/routes/board-settings-route/board-settings-route.tsx
+++ b/apps/web/app/routes/board-settings-route/board-settings-route.tsx
@@ -1,8 +1,7 @@
 import { data } from "react-router";
 import type { Route } from "./+types/board-settings-route";
 import verifyAuthentication from "~/libs/auth";
-import { isApiErrorResponse, type ApiResponse, type Board } from "types";
-import { RouteErrorResponse } from "~/root";
+import { isErrorData, type ApiData, type Board } from "types";
 import NameSetting from "./name-setting";
 import TimezoneSetting from "./timezone-setting";
 
@@ -11,7 +10,7 @@ function getBoard(boardId: string, { accessToken }: { accessToken: string }) {
     headers: {
       Authorization: `Bearer ${accessToken}`,
     },
-  }).then((response) => response.json() as Promise<ApiResponse<Board>>);
+  }).then((response) => response.json() as Promise<ApiData<Board>>);
 }
 
 export async function loader({ request, params }: Route.LoaderArgs) {
@@ -20,13 +19,10 @@ export async function loader({ request, params }: Route.LoaderArgs) {
   const boardId = params.boardId;
 
   const boardPromise = getBoard(boardId, { accessToken }).then((data) => {
-    if (isApiErrorResponse(data)) {
-      throw new RouteErrorResponse(
-        data.statusCode,
-        data.message,
-        Error(data.error)
-      );
+    if (isErrorData(data)) {
+      return null;
     }
+
     return data;
   });
 

--- a/apps/web/app/routes/board-settings-route/name-setting.tsx
+++ b/apps/web/app/routes/board-settings-route/name-setting.tsx
@@ -15,6 +15,10 @@ function NameSetting({}: Props) {
 
   const board = use(boardPromise);
 
+  if (!board) {
+    return null;
+  }
+
   const boardName = updateBoardNameFetcher.json
     ? (updateBoardNameFetcher.json as { name: string }).name
     : board.name;

--- a/apps/web/app/routes/board-settings-route/timezone-setting.tsx
+++ b/apps/web/app/routes/board-settings-route/timezone-setting.tsx
@@ -110,6 +110,10 @@ function TimezoneSetting({}: Props) {
 
   const board = use(boardPromise);
 
+  if (!board) {
+    return null;
+  }
+
   const boardTimezone = updateBoardTimezoneFetcher.json
     ? (updateBoardTimezoneFetcher.json as { timezone: string }).timezone
     : board.timezone;

--- a/apps/web/app/routes/create-board-standup/create-board-standup.tsx
+++ b/apps/web/app/routes/create-board-standup/create-board-standup.tsx
@@ -1,7 +1,7 @@
 import verifyAuthentication from "~/libs/auth";
 import type { Route } from "./+types/create-board-standup";
-import { isApiErrorResponse } from "types";
-import type { ApiResponse } from "types";
+import { isErrorData } from "types";
+import type { ApiData } from "types";
 import type { Standup } from "types";
 import { data } from "react-router";
 import { commitSession } from "~/libs/auth-session.server";
@@ -23,7 +23,7 @@ function createStandup(
       "Content-Type": "application/json",
       Authorization: `Bearer ${accessToken}`,
     },
-  }).then((response) => response.json() as Promise<ApiResponse<Standup>>);
+  }).then((response) => response.json() as Promise<ApiData<Standup>>);
 }
 
 export type ActionType = typeof action;
@@ -37,7 +37,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const boardId = params.boardId;
 
-  const response = await createStandup(
+  const standupData = await createStandup(
     boardId,
     { formData, formStructureId: Number(formStructureId) },
     {
@@ -47,13 +47,13 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   return data(
     {
-      ...(isApiErrorResponse(response)
+      ...(isErrorData(standupData)
         ? {
-            error: response.message,
+            error: standupData.message,
             standup: null,
           }
         : {
-            standup: response,
+            standup: standupData,
             error: null,
           }),
     },

--- a/apps/web/app/routes/create-new-board-route/create-new-board-route.tsx
+++ b/apps/web/app/routes/create-new-board-route/create-new-board-route.tsx
@@ -16,7 +16,7 @@ import {
 import verifyAuthentication from "~/libs/auth";
 import { commitSession } from "~/libs/auth-session.server";
 import type { Route } from "./+types/create-new-board-route";
-import { isApiErrorResponse, type ApiResponse, type Board } from "types";
+import { isErrorData, type ApiData, type Board } from "types";
 
 export async function loader({ request }: Route.LoaderArgs) {
   await verifyAuthentication(request);
@@ -60,7 +60,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
   const timezone = formData.get("timezone")?.toString().trim();
 
-  const board = await fetch(import.meta.env.VITE_API_URL + "/boards", {
+  const boardData = await fetch(import.meta.env.VITE_API_URL + "/boards", {
     method: "POST",
     body: JSON.stringify({ name, timezone }),
     headers: {
@@ -68,11 +68,11 @@ export async function action({ request }: ActionFunctionArgs) {
       Authorization: `Bearer ${accessToken}`,
     },
   }).then(async (response) => {
-    const data: ApiResponse<Board> = await response.json();
+    const data: ApiData<Board> = await response.json();
     return data;
   });
 
-  if (isApiErrorResponse(board)) {
+  if (isErrorData(boardData)) {
     return data(
       {
         errors: {
@@ -87,7 +87,7 @@ export async function action({ request }: ActionFunctionArgs) {
     );
   }
 
-  return redirect("/boards/" + board.id, {
+  return redirect("/boards/" + boardData.id, {
     headers: {
       ...(session ? { "Set-Cookie": await commitSession(session) } : {}),
     },

--- a/apps/web/app/routes/index-route/index-route.tsx
+++ b/apps/web/app/routes/index-route/index-route.tsx
@@ -1,12 +1,6 @@
 import verifyAuthentication from "~/libs/auth";
 import type { Route } from "./+types/index-route";
-import {
-  isApiErrorResponse,
-  type ApiResponse,
-  type Board,
-  type User,
-} from "types";
-import { RouteErrorResponse } from "~/root";
+import { isErrorData, type ApiData, type Board, type User } from "types";
 import { redirect } from "react-router";
 
 export async function loader({ request }: Route.LoaderArgs) {
@@ -20,18 +14,18 @@ export async function loader({ request }: Route.LoaderArgs) {
       },
     }
   ).then(async (response) => {
-    const data = (await response.json()) as ApiResponse<User>;
+    const userData = (await response.json()) as ApiData<User>;
 
-    if (isApiErrorResponse(data)) {
-      throw new RouteErrorResponse(
-        data.statusCode,
-        data.message,
-        Error(data.error)
-      );
+    if (isErrorData(userData)) {
+      return null;
     }
 
-    return data;
+    return userData;
   });
+
+  if (!currentUser) {
+    return redirect("/access");
+  }
 
   const lastAccessedBoardId =
     currentUser.client_read_only_metadata?.lastAccessedBoardId;

--- a/apps/web/app/routes/send-access-code-route/send-access-code-route.tsx
+++ b/apps/web/app/routes/send-access-code-route/send-access-code-route.tsx
@@ -1,5 +1,5 @@
 import type { Route } from "./+types/send-access-code-route";
-import { isApiErrorResponse, type ApiResponse, type ListUser } from "types";
+import { isErrorData, type ApiData, type ListUser } from "types";
 import { data } from "react-router";
 import { redirect } from "react-router";
 
@@ -14,9 +14,7 @@ function sendAccessCode(email: string) {
     headers: {
       "Content-Type": "application/json",
     },
-  }).then(
-    (response) => response.json() as Promise<ApiResponse<{ nonce: string }>>
-  );
+  }).then((response) => response.json() as Promise<ApiData<{ nonce: string }>>);
 }
 
 function checkIfUserExists(email: string) {
@@ -29,13 +27,13 @@ function checkIfUserExists(email: string) {
         "Content-Type": "application/json",
       },
     }
-  ).then((response) => response.json() as Promise<ApiResponse<boolean>>);
+  ).then((response) => response.json() as Promise<ApiData<boolean>>);
 }
 
 async function determineRedirectUrl(email: string) {
   const userExistsResponse = await checkIfUserExists(email);
 
-  if (isApiErrorResponse(userExistsResponse)) {
+  if (isErrorData(userExistsResponse)) {
     return "/access/sign-in";
   }
 
@@ -47,15 +45,15 @@ export type ActionType = typeof action;
 export async function action({ request }: Route.ActionArgs) {
   const { email } = (await request.json()) as SendAccessCodeRequestBody;
 
-  const sendAccessCodeResponse = await sendAccessCode(email);
+  const responseData = await sendAccessCode(email);
 
-  if (isApiErrorResponse(sendAccessCodeResponse)) {
+  if (isErrorData(responseData)) {
     return data({
-      error: sendAccessCodeResponse.message,
+      error: responseData.message,
     });
   }
 
-  const { nonce } = sendAccessCodeResponse;
+  const { nonce } = responseData;
 
   const redirectUrl = await determineRedirectUrl(email);
 

--- a/apps/web/app/routes/sign-in-with-access-code-route/sign-in-with-access-code-route.tsx
+++ b/apps/web/app/routes/sign-in-with-access-code-route/sign-in-with-access-code-route.tsx
@@ -1,4 +1,4 @@
-import { isApiErrorResponse, type ApiResponse } from "types";
+import { isErrorData, type ApiData } from "types";
 import type { Route } from "./+types/sign-in-with-access-code-route";
 import { data, redirect } from "react-router";
 import { commitSession, getSession } from "~/libs/auth-session.server";
@@ -18,7 +18,7 @@ function signInWithAccessCode(otp: string, nonce: string) {
   }).then(
     (response) =>
       response.json() as Promise<
-        ApiResponse<{
+        ApiData<{
           access_token: string;
           refresh_token: string;
           is_new_user: boolean;
@@ -34,18 +34,18 @@ export async function action({ request }: Route.ActionArgs) {
   const { otp, nonce } =
     (await request.json()) as SignInWithAccessCodeRequestBody;
 
-  const response = await signInWithAccessCode(otp, nonce);
+  const responseData = await signInWithAccessCode(otp, nonce);
 
-  if (isApiErrorResponse(response)) {
+  if (isErrorData(responseData)) {
     return data({
-      error: response.message,
+      error: responseData.message,
     });
   }
 
   const session = await getSession(request.headers.get("Cookie"));
 
-  session.set("access_token", response.access_token);
-  session.set("refresh_token", response.refresh_token);
+  session.set("access_token", responseData.access_token);
+  session.set("refresh_token", responseData.refresh_token);
 
   return redirect("/", {
     headers: { "Set-Cookie": await commitSession(session) },

--- a/apps/web/app/routes/update-board-route/update-board-route.tsx
+++ b/apps/web/app/routes/update-board-route/update-board-route.tsx
@@ -1,4 +1,4 @@
-import { isApiErrorResponse, type ApiResponse } from "types";
+import { isErrorData, type ApiData } from "types";
 import type { Board } from "types";
 import type { Route } from "./+types/update-board-route";
 import verifyAuthentication from "~/libs/auth";
@@ -23,7 +23,7 @@ function updateBoard(
       Authorization: `Bearer ${accessToken}`,
     },
   }).then(async (response) => {
-    const data: ApiResponse<Board> = await response.json();
+    const data: ApiData<Board> = await response.json();
 
     return data;
   });
@@ -39,7 +39,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   const { name, timezone } = (await request.json()) as UpdateBoardRequestBody;
 
-  const response = await updateBoard(
+  const responseData = await updateBoard(
     boardId,
     { name, timezone },
     { accessToken }
@@ -47,13 +47,13 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   return data(
     {
-      ...(isApiErrorResponse(response)
+      ...(isErrorData(responseData)
         ? {
-            error: response.message,
+            error: responseData.message,
             board: null,
           }
         : {
-            board: response,
+            board: responseData,
             error: null,
           }),
     },

--- a/apps/web/app/routes/update-board-standup/update-board-standup.tsx
+++ b/apps/web/app/routes/update-board-standup/update-board-standup.tsx
@@ -1,4 +1,4 @@
-import { isApiErrorResponse, type ApiResponse } from "types";
+import { isErrorData, type ApiData } from "types";
 import type { Standup } from "types";
 import type { Route } from "./+types/update-board-standup";
 import verifyAuthentication from "~/libs/auth";
@@ -25,22 +25,21 @@ function updateStandup(
         Authorization: `Bearer ${accessToken}`,
       },
     }
-  ).then((response) => response.json() as Promise<ApiResponse<Standup>>);
+  ).then((response) => response.json() as Promise<ApiData<Standup>>);
 }
 
 export type ActionType = typeof action;
 
 export async function action({ request, params }: Route.ActionArgs) {
-  const { accessToken, refreshed, session } = await verifyAuthentication(
-    request
-  );
+  const { accessToken, refreshed, session } =
+    await verifyAuthentication(request);
 
   const boardId = params.boardId;
   const standupId = params.standupId;
 
   const { formData } = (await request.json()) as UpdateStandupRequestBody;
 
-  const response = await updateStandup(
+  const responseData = await updateStandup(
     boardId,
     standupId,
     { formData },
@@ -49,13 +48,13 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   return data(
     {
-      ...(isApiErrorResponse(response)
+      ...(isErrorData(responseData)
         ? {
-            error: response.message,
+            error: responseData.message,
             standup: null,
           }
         : {
-            standup: response,
+            standup: responseData,
             error: null,
           }),
     },

--- a/apps/web/types.ts
+++ b/apps/web/types.ts
@@ -67,21 +67,19 @@ export interface Standup {
  * API
  */
 
-interface ApiErrorResponse {
+interface ErrorData {
   message: string;
   statusCode: number;
   error?: string;
 }
 
-export function isApiErrorResponse(
-  response: unknown
-): response is ApiErrorResponse {
+export function isErrorData(data: unknown): data is ErrorData {
   return (
-    typeof response === "object" &&
-    response !== null &&
-    "message" in response &&
-    "statusCode" in response
+    typeof data === "object" &&
+    data !== null &&
+    "message" in data &&
+    "statusCode" in data
   );
 }
 
-export type ApiResponse<T> = T | ApiErrorResponse;
+export type ApiData<T> = T | ErrorData;


### PR DESCRIPTION
![Apr-17-2025 15-37-55](https://github.com/user-attachments/assets/237d733b-5399-4f4f-829a-4370a8a0ac83)

<br>

- I found that the `Error boundary` in the `root file` handles not-found pages and pages that need permission.
- So I used the `Error boundary` to deal with those cases.
- We can handle these cases by customizing the ErrorBoundary.

<br>
Ref : https://reactrouter.com/how-to/error-boundary