### PR TITLE
STNDP-32 Support keyboard shortcut for standup forms

### DIFF
--- a/apps/web/app/routes/board-route/dynamic-form.tsx
+++ b/apps/web/app/routes/board-route/dynamic-form.tsx
@@ -1,5 +1,14 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Flex, Box, TextArea, Button, Text, Skeleton } from "@radix-ui/themes";
+import {
+  Flex,
+  Box,
+  TextArea,
+  Button,
+  Text,
+  Skeleton,
+  Card,
+} from "@radix-ui/themes";
+import { forwardRef, useImperativeHandle } from "react";
 import { useForm, Controller } from "react-hook-form";
 import { z } from "zod";
 
@@ -62,216 +71,241 @@ export type DynamicFormValues = {
   [key: string]: any; // Allows dynamic field names
 };
 
-function DynamicForm({
-  schema,
-  defaultValues,
-  onSubmit,
-  onCancel,
-  loading,
-}: {
+export interface DynamicFormHandle {
+  triggerSubmit: () => void;
+}
+
+interface DynamicFormProps {
   schema: z.infer<typeof dynamicFormSchema>;
   defaultValues?: DynamicFormValues;
   onSubmit: (data: DynamicFormValues) => void;
   onCancel?: () => void;
   loading?: boolean;
-}) {
-  const { title, description, fields } = schema;
-
-  const dynamicFormSchema = z.object(
-    fields.reduce((acc, field) => {
-      if (field.type === "textarea") {
-        let fieldValidation = z.string();
-
-        if (field.validations) {
-          fieldValidation = fieldValidation
-            .min(field.validations.minLength || 0)
-            .max(field.validations.maxLength || Infinity);
-        }
-
-        acc[field.name] = field.required
-          ? fieldValidation.nonempty()
-          : fieldValidation.optional();
-      }
-
-      return acc;
-    }, {} as { [key: string]: z.ZodType })
-  );
-
-  const {
-    control,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<DynamicFormValues>({
-    resolver: zodResolver(dynamicFormSchema),
-    defaultValues:
-      defaultValues ||
-      fields.reduce((acc, field) => {
-        acc[field.name] = field.defaultValue || "";
-        return acc;
-      }, {} as DynamicFormValues),
-  });
-
-  return (
-    <form
-      method="post"
-      onSubmit={handleSubmit((data) => {
-        onSubmit(data);
-      })}
-    >
-      <Flex direction="column">
-        <Text size="4" weight="bold">
-          {title}
-        </Text>
-        {description && (
-          <Text size="2" mt="1">
-            {description}
-          </Text>
-        )}
-        <Flex direction="column" mt="5" gap="5">
-          {fields.map((field) => {
-            return (
-              <Flex key={field.name} direction="column" gap="2">
-                <label>
-                  <Flex align="center" gap="2">
-                    <Text
-                      size="2"
-                      className="font-[var(--font-weight-semibold)]"
-                    >
-                      {field.label}
-                    </Text>
-                    {field.required && (
-                      <Text size="1" color="gray">
-                        Required
-                      </Text>
-                    )}
-                  </Flex>
-                </label>
-                {field.type === "textarea" && (
-                  <Controller
-                    name={field.name}
-                    control={control}
-                    render={({ field: { onChange, value } }) => (
-                      <TextArea
-                        value={value}
-                        onChange={onChange}
-                        variant="soft"
-                        placeholder={field.placeholder}
-                        className="w-full !min-h-[80px]"
-                        resize="vertical"
-                      />
-                    )}
-                  />
-                )}
-
-                {field.description && (
-                  <Text size="2" color="gray">
-                    {field.description}
-                  </Text>
-                )}
-
-                {errors[field.name] && (
-                  <Text size="2" color="red">
-                    {(errors[field.name]?.message as string) || "Invalid input"}
-                  </Text>
-                )}
-              </Flex>
-            );
-          })}
-        </Flex>
-        <Flex justify="end" mt="5" gap="2">
-          {defaultValues && (
-            <Button
-              highContrast
-              type="button"
-              size="2"
-              variant="surface"
-              onClick={onCancel}
-            >
-              Cancel
-            </Button>
-          )}
-          <Button highContrast size="2" type="submit" loading={loading}>
-            Save
-          </Button>
-        </Flex>
-      </Flex>
-    </form>
-  );
 }
+
+const DynamicForm = forwardRef<DynamicFormHandle, DynamicFormProps>(
+  ({ schema, defaultValues, onSubmit, onCancel, loading }, ref) => {
+    const { title, description, fields } = schema;
+
+    const dynamicFormSchema = z.object(
+      fields.reduce(
+        (acc, field) => {
+          if (field.type === "textarea") {
+            let fieldValidation = z.string();
+
+            if (field.validations) {
+              fieldValidation = fieldValidation
+                .min(field.validations.minLength || 0)
+                .max(field.validations.maxLength || Infinity);
+            }
+
+            acc[field.name] = field.required
+              ? fieldValidation.nonempty()
+              : fieldValidation.optional();
+          }
+
+          return acc;
+        },
+        {} as { [key: string]: z.ZodType }
+      )
+    );
+
+    const {
+      control,
+      handleSubmit,
+      formState: { errors },
+    } = useForm<DynamicFormValues>({
+      resolver: zodResolver(dynamicFormSchema),
+      defaultValues:
+        defaultValues ||
+        fields.reduce((acc, field) => {
+          acc[field.name] = field.defaultValue || "";
+          return acc;
+        }, {} as DynamicFormValues),
+    });
+
+    useImperativeHandle(ref, () => ({
+      triggerSubmit: () => {
+        handleSubmit(onSubmit)();
+      },
+    }));
+
+    return (
+      <form
+        method="post"
+        onSubmit={handleSubmit((data) => {
+          onSubmit(data);
+        })}
+        onKeyDown={(e) => {
+          if (e.metaKey && e.key === "Enter") {
+            e.preventDefault();
+            handleSubmit(onSubmit)();
+          }
+        }}
+      >
+        <Flex direction="column">
+          <Text size="4" weight="bold">
+            {title}
+          </Text>
+          {description && (
+            <Text size="2" mt="1">
+              {description}
+            </Text>
+          )}
+          <Flex direction="column" mt="5" gap="5">
+            {fields.map((field) => {
+              return (
+                <Flex key={field.name} direction="column" gap="2">
+                  <label>
+                    <Flex align="center" gap="2">
+                      <Text
+                        size="2"
+                        className="font-[var(--font-weight-semibold)]"
+                      >
+                        {field.label}
+                      </Text>
+                      {field.required && (
+                        <Text size="1" color="gray">
+                          Required
+                        </Text>
+                      )}
+                    </Flex>
+                  </label>
+                  {field.type === "textarea" && (
+                    <Controller
+                      name={field.name}
+                      control={control}
+                      render={({ field: { onChange, value } }) => (
+                        <TextArea
+                          value={value}
+                          onChange={onChange}
+                          variant="soft"
+                          placeholder={field.placeholder}
+                          className="w-full !min-h-[80px]"
+                          resize="vertical"
+                        />
+                      )}
+                    />
+                  )}
+
+                  {field.description && (
+                    <Text size="2" color="gray">
+                      {field.description}
+                    </Text>
+                  )}
+
+                  {errors[field.name] && (
+                    <Text size="2" color="red">
+                      {(errors[field.name]?.message as string) ||
+                        "Invalid input"}
+                    </Text>
+                  )}
+                </Flex>
+              );
+            })}
+          </Flex>
+          <Flex justify="end" mt="5" gap="2">
+            {defaultValues && (
+              <Button
+                highContrast
+                type="button"
+                size="2"
+                variant="surface"
+                onClick={onCancel}
+              >
+                Cancel
+              </Button>
+            )}
+            <Button highContrast size="2" type="submit" loading={loading}>
+              Save
+            </Button>
+          </Flex>
+        </Flex>
+      </form>
+    );
+  }
+);
 
 export default DynamicForm;
 
 export function FormSkeleton() {
   return (
-    <form>
-      <Flex direction="column">
-        <Text size="4" weight="bold">
-          <Skeleton>Today's Standup</Skeleton>
-        </Text>
-        <Box mt="5">
-          <Flex direction="column" gap="2">
-            <label>
-              <Flex>
-                <Text size="2" weight="medium">
-                  <Skeleton>What did you do yesterday? *</Skeleton>
-                </Text>
-              </Flex>
-            </label>
-            <Text
-              size="2"
-              color="gray"
-              className="max-h-[80px] overflow-hidden"
-            >
-              <Skeleton width="100%">
-                {Array.from({ length: 500 }).map((_, index) => "A")}
-              </Skeleton>
-            </Text>
-          </Flex>
+    <Card
+      size={{
+        initial: "2",
+        sm: "4",
+      }}
+    >
+      <form>
+        <Flex direction="column">
+          <Text size="4" weight="bold">
+            <Skeleton>Today's Standup</Skeleton>
+          </Text>
+          <Box mt="5">
+            <Flex direction="column" gap="2">
+              <label>
+                <Flex>
+                  <Text size="2" weight="medium">
+                    <Skeleton>What did you do yesterday? *</Skeleton>
+                  </Text>
+                </Flex>
+              </label>
+              <Text
+                size="2"
+                color="gray"
+                className="max-h-[80px] overflow-hidden"
+              >
+                <Skeleton width="100%">
+                  {Array.from({ length: 500 }).map((_, index) => "A")}
+                </Skeleton>
+              </Text>
+            </Flex>
 
-          <Flex direction="column" gap="2" mt="5">
-            <label>
-              <Flex>
-                <Text size="2" weight="medium">
-                  <Skeleton>What will you do today? *</Skeleton>
-                </Text>
-              </Flex>
-            </label>
-            <Text
-              size="2"
-              color="gray"
-              className="max-h-[80px] overflow-hidden"
-            >
-              <Skeleton width="100%">
-                {Array.from({ length: 500 }).map((_, index) => "A")}
-              </Skeleton>
-            </Text>
-          </Flex>
+            <Flex direction="column" gap="2" mt="5">
+              <label>
+                <Flex>
+                  <Text size="2" weight="medium">
+                    <Skeleton>What will you do today? *</Skeleton>
+                  </Text>
+                </Flex>
+              </label>
+              <Text
+                size="2"
+                color="gray"
+                className="max-h-[80px] overflow-hidden"
+              >
+                <Skeleton width="100%">
+                  {Array.from({ length: 500 }).map((_, index) => "A")}
+                </Skeleton>
+              </Text>
+            </Flex>
 
-          <Flex direction="column" gap="2" mt="5">
-            <label>
-              <Flex>
-                <Text size="2" weight="medium">
-                  <Skeleton>Do you have any blockers?</Skeleton>
-                </Text>
-              </Flex>
-            </label>
-            <Text
-              size="2"
-              color="gray"
-              className="max-h-[80px] overflow-hidden"
-            >
-              <Skeleton width="100%">
-                {Array.from({ length: 500 }).map((_, index) => "A")}
-              </Skeleton>
-            </Text>
+            <Flex direction="column" gap="2" mt="5">
+              <label>
+                <Flex>
+                  <Text size="2" weight="medium">
+                    <Skeleton>Do you have any blockers?</Skeleton>
+                  </Text>
+                </Flex>
+              </label>
+              <Text
+                size="2"
+                color="gray"
+                className="max-h-[80px] overflow-hidden"
+              >
+                <Skeleton width="100%">
+                  {Array.from({ length: 500 }).map((_, index) => "A")}
+                </Skeleton>
+              </Text>
+            </Flex>
+          </Box>
+          <Flex justify="end" mt="5" gap="2">
+            <Skeleton>
+              <Button size="2">Save</Button>
+            </Skeleton>
           </Flex>
-        </Box>
-        <Flex justify="end" mt="5" gap="2">
-          <Skeleton>
-            <Button size="2">Save</Button>
-          </Skeleton>
         </Flex>
-      </Flex>
-    </form>
+      </form>
+    </Card>
   );
 }

--- a/apps/web/app/routes/board-route/todays-standup.tsx
+++ b/apps/web/app/routes/board-route/todays-standup.tsx
@@ -1,11 +1,12 @@
 import { Box, Button, Card, Flex, Text } from "@radix-ui/themes";
-import { Suspense, use, useEffect, useState } from "react";
+import { Suspense, use, useEffect, useRef, useState } from "react";
 import { useFetcher, useLoaderData } from "react-router";
 import type { loader } from "./board-route";
 import { DateTime } from "luxon";
 import DynamicForm, {
   FormSkeleton,
   validateDynamicFormSchema,
+  type DynamicFormHandle,
   type DynamicFormValues,
 } from "./dynamic-form";
 import {
@@ -111,10 +112,27 @@ function CardContent() {
 
   const [isEditing, setIsEditing] = useState(!Boolean(todayStandup));
 
+  const formRef = useRef<DynamicFormHandle>(null);
+
   return (
-    <>
+    <Card
+      tabIndex={0}
+      size={{
+        initial: "2",
+        sm: "4",
+      }}
+      onKeyDown={(e) => {
+        if (e.key.toLowerCase() === "e") {
+          setIsEditing(true);
+        }
+        if (e.metaKey && e.key === "Enter") {
+          formRef.current?.triggerSubmit();
+        }
+      }}
+    >
       {!todayStandup && (
         <DynamicForm
+          ref={formRef}
           schema={schema}
           onSubmit={async (data) => {
             if (!structure) {
@@ -200,23 +218,15 @@ function CardContent() {
             </Flex>
           </Flex>
         ))}
-    </>
+    </Card>
   );
 }
 
 function TodaysStandup({}: Props) {
   return (
-    <Card
-      tabIndex={0}
-      size={{
-        initial: "2",
-        sm: "4",
-      }}
-    >
-      <Suspense fallback={<FormSkeleton />}>
-        <CardContent />
-      </Suspense>
-    </Card>
+    <Suspense fallback={<FormSkeleton />}>
+      <CardContent />
+    </Suspense>
   );
 }
 


### PR DESCRIPTION
### Change 1: Moved `<Card>` component
- Before, the `<Card>` was wrapping other components like `<Suspense>`. _(from function TodaysStandup)_

- Now, I moved the `<Card>` inside each child component like `<CardContent>` and `<FormSkeleton>`.

- Note: `<FormSkeleton>` didn’t really change — I only added a `<Card>` around it, so some parts of the code moved around. 

#### Reason
- I needed to add a keyboard shortcut (`e` key → Edit mode) when the Card is focused.

- To do that, the event handler had to be inside `<CardContent>`, so I moved `<Card>` into it.

- Because of this, maybe the name `CardContent` is not perfect anymore and could be changed later.

<br><br><br>

### Change 2: Added forwardRef and useImperativeHandle to `<DynamicForm>` component
- I used forwardRef on the `<DynamicForm>` component. 

- Inside it, I used useImperativeHandle to expose a handleSubmit function to the parent.

- Note : The `<DynamicForm>` component now uses forwardRef, so some parts of the code moved around. But there were no important logic changes.

#### Reason
- I needed to add another keyboard shortcut (`cmd + Enter` → submit) when the Card is focused.

- To make this work, the parent component needs to trigger the submit from outside.

- So I updated the structure to make `<DynamicForm>` support that.


<br><br>

> P.S. This update was made with a lot of help from ChatGPT
> It was my first time trying `useImperativeHandle`...