### PR TITLE
Fix invitation error handling logic

### DIFF
--- a/apps/api/src/boards/invitation/invitation.service.ts
+++ b/apps/api/src/boards/invitation/invitation.service.ts
@@ -19,11 +19,32 @@ import { addDurationToNow } from 'src/libs/date';
 /**
  * Service for managing board invitations.
  *
- * DESIGN NOTE: Invitations in this system are designed to be REUSABLE.
- * - Each board can have one active invitation at a time
+ * DESIGN NOTE: This service treats ACTIVE INVITATIONS as a SINGLETON pattern.
+ * 
+ * Active Invitation Singleton Pattern:
+ * - Each board can have ONLY ONE active invitation at any given time
+ * - An "active" invitation is defined as: NOT deactivated AND NOT expired
+ * - All methods in this service work with this singleton assumption
+ * 
+ * Key behaviors:
+ * - `create()` - Throws error if active invitation already exists
+ * - `ensure()` - Returns existing active invitation OR creates new one
+ * - `regenerate()` - Deactivates existing active invitation, then creates new one
+ * - `get()` - Returns the single active invitation for a board (or null)
+ * - `getByToken()` - Returns active invitation by token (or throws NotFoundException)
+ * - `deactivate()` - Deactivates the active invitation
+ * - `accept()` - Uses active invitation to add user to board
+ * 
+ * Invitation Reusability:
+ * - The single active invitation is REUSABLE by multiple users
  * - Multiple users can use the same invitation token to join a board
  * - Invitations remain active until manually deactivated or expired
  * - This is intentional behavior to simplify invitation management
+ * 
+ * Error Handling Philosophy:
+ * - Deactivated invitations are treated as if they don't exist
+ * - Expired invitations are treated as if they don't exist
+ * - Only "not found" errors are exposed to users for invalid invitations
  */
 @Injectable()
 export class InvitationService {


### PR DESCRIPTION
Refactor invitation retrieval to centralize active invitation validation and simplify error handling.

A new private `getInvitationByToken` method now encapsulates the logic for retrieving only active invitations (not deactivated or expired). This allows `getByToken` to maintain its existing 'not found or has expired' message, while `accept` can consistently throw a simpler 'Invitation not found' for any invalid invitation state (deactivated, expired, or non-existent).