### PR TITLE
Troubleshoot Safari error

### DIFF
--- a/apps/web/app/context/ColorSchemeContext.tsx
+++ b/apps/web/app/context/ColorSchemeContext.tsx
@@ -21,6 +21,9 @@ const ColorSchemeContext = createContext<ColorSchemeContext>(defaultValue);
  */
 function useCleanupFlickerPrevention(colorScheme: ColorScheme | null) {
   useEffect(() => {
+    // Ensure we're on the client side before accessing document
+    if (typeof window === "undefined") return;
+    
     if (colorScheme) {
       document.documentElement.removeAttribute("class");
     }
@@ -35,6 +38,9 @@ function useDetermineColorScheme(
   setColorScheme: (colorScheme: ColorScheme | null) => void
 ) {
   useEffect(() => {
+    // Ensure we're on the client side before accessing window
+    if (typeof window === "undefined") return;
+    
     if (appearance === "inherit") {
       const prefersDark = window.matchMedia(
         "(prefers-color-scheme: dark)"
@@ -44,7 +50,7 @@ function useDetermineColorScheme(
     }
 
     setColorScheme(appearance);
-  }, [appearance]);
+  }, [appearance, setColorScheme]);
 }
 
 /**
@@ -55,6 +61,9 @@ function useHandleSystemColorSchemeChange(
   setColorScheme: (colorScheme: ColorScheme | null) => void
 ) {
   useEffect(() => {
+    // Ensure we're on the client side before accessing window
+    if (typeof window === "undefined") return;
+    
     if (appearance === "inherit") {
       const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
 
@@ -68,7 +77,7 @@ function useHandleSystemColorSchemeChange(
         mediaQuery.removeEventListener("change", handleSystemColorSchemeChange);
       };
     }
-  }, [appearance]);
+  }, [appearance, setColorScheme]);
 }
 
 export const ColorSchemeProvider: React.FC<{

--- a/apps/web/app/context/UserAppearanceSettingContext.tsx
+++ b/apps/web/app/context/UserAppearanceSettingContext.tsx
@@ -17,6 +17,9 @@ function useLoadAppearanceSetting(
   setAppearance: (appearance: Appearance) => void
 ) {
   useEffect(() => {
+    // Ensure we're on the client side before accessing localStorage
+    if (typeof window === "undefined") return;
+    
     const userAppearanceSetting =
       localStorage.getItem("user-appearance-setting") || "inherit";
 
@@ -33,7 +36,7 @@ function useLoadAppearanceSetting(
       setAppearance("dark");
       return;
     }
-  }, []);
+  }, [setAppearance]);
 }
 
 const UserAppearanceSettingContext =
@@ -50,7 +53,10 @@ export const UserAppearanceSettingProvider: React.FC<{
 
   function handleAppearanceChange(value: Appearance) {
     setAppearance(value);
-    localStorage.setItem("user-appearance-setting", value);
+    // Ensure we're on the client side before accessing localStorage
+    if (typeof window !== "undefined") {
+      localStorage.setItem("user-appearance-setting", value);
+    }
   }
 
   return (


### PR DESCRIPTION
Add client-side checks for `window` and `localStorage` access to resolve React hydration errors in Safari.

This PR addresses an "Invalid hook call" error observed in Safari, stemming from hydration mismatches during server-side rendering (SSR). Context providers were attempting to access browser-specific APIs like `localStorage` and `window` on the server, leading to discrepancies between server-rendered and client-hydrated content. Safari, especially with React 19, is particularly sensitive to these mismatches.