### PR TITLE
Reuse current user data promise

### DIFF
--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -124,26 +124,21 @@ export async function loader({ request }: Route.LoaderArgs) {
   } = await verifyAndRefreshAccessToken(session);
 
   let currentUser: User | null = null;
+  let currentUserPromise: Promise<User | null> | null = null;
 
   if (isValid) {
-    currentUser = await getCurrentUser(accessToken).then((data) => {
+    currentUserPromise = getCurrentUser(accessToken).then((data) => {
       if (isErrorData(data)) {
         return null;
       }
       return data;
     });
+    currentUser = await currentUserPromise;
   }
 
   return data(
     {
-      currentUserPromise: isValid
-        ? getCurrentUser(accessToken).then((data) => {
-            if (isErrorData(data)) {
-              return null;
-            }
-            return data;
-          })
-        : null,
+      currentUserPromise,
       currentUser,
     },
     {


### PR DESCRIPTION
Eliminate duplicate `getCurrentUser` API calls in `root.tsx` loader to improve performance.

The `loader` previously called `getCurrentUser` twice when the access token was valid, once to populate `currentUser` and again to create `currentUserPromise`, resulting in redundant network requests.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-de97bb1a-8b46-4ba0-9915-f1921fb19126) · [Cursor](https://cursor.com/background-agent?bcId=bc-de97bb1a-8b46-4ba0-9915-f1921fb19126)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)